### PR TITLE
Attach template names to issuers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,9 @@ manifests: controller-gen
 helm-docs: helm-tool
 	$(HELM_TOOL) inject -i charts/aws-pca-issuer/values.yaml -o charts/aws-pca-issuer/README.md --header-search "^<!-- AUTO-GENERATED -->" --footer-search "<!-- /AUTO-GENERATED -->"
 
-# Run go fmt against code
-fmt:
-	go fmt ./...
+# Run goimports against code
+fmt: goimports-tool
+	$(GOIMPORTS_TOOL) -w .
 
 # Run go vet against code
 vet:
@@ -166,6 +166,10 @@ controller-gen:
 HELM_TOOL = $(shell pwd)/bin/helm-tool
 helm-tool:
 	$(call go-install-tool,$(HELM_TOOL),github.com/cert-manager/helm-tool@$(HELM_TOOL_VERSION))
+
+GOIMPORTS_TOOL = $(shell pwd)/bin/goimports
+goimports-tool:
+	$(call go-install-tool,$(GOIMPORTS_TOOL),golang.org/x/tools/cmd/goimports@latest)
 
 # Download kustomize locally if necessary
 KUSTOMIZE = $(shell pwd)/bin/kustomize

--- a/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaclusterissuers.yaml
+++ b/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaclusterissuers.yaml
@@ -38,7 +38,7 @@ spec:
             description: AWSPCAIssuerSpec defines the desired state of AWSPCAIssuer
             properties:
               pcaTemplateName:
-                description: Specifies the template name associated with the issuer, all requests made to this issuer will use this template. If not specified, the issuer will follow the fields on the certificate resource.
+                description: Specifies the template name associated with the issuer, all requests made to this issuer will use this template. If not specified, the issuer will use the usageTypes on the certificate resource.
                 type: string 
               arn:
                 description: Specifies the ARN of the PCA resource

--- a/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaclusterissuers.yaml
+++ b/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaclusterissuers.yaml
@@ -38,8 +38,7 @@ spec:
             description: AWSPCAIssuerSpec defines the desired state of AWSPCAIssuer
             properties:
               pcaTemplateName:
-                description: Specifies the template name of the issuer
-                  certificates. If not specified, the issuer will follow the fields on the certificate resource.
+                description: Specifies the template name associated with the issuer, all requests made to this issuer will use this template. If not specified, the issuer will follow the fields on the certificate resource.
                 type: string 
               arn:
                 description: Specifies the ARN of the PCA resource

--- a/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaclusterissuers.yaml
+++ b/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaclusterissuers.yaml
@@ -37,6 +37,10 @@ spec:
           spec:
             description: AWSPCAIssuerSpec defines the desired state of AWSPCAIssuer
             properties:
+              pcaTemplateName:
+                description: Specifies the template name of the issuer
+                  certificates. If not specified, the issuer will follow the fields on the certificate resource.
+                type: string 
               arn:
                 description: Specifies the ARN of the PCA resource
                 type: string

--- a/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaissuers.yaml
+++ b/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaissuers.yaml
@@ -36,6 +36,10 @@ spec:
           spec:
             description: AWSPCAIssuerSpec defines the desired state of AWSPCAIssuer
             properties:
+              pcaTemplateName:
+                description: Specifies the template name of the issuer
+                  certificates. If not specified, the issuer will follow the fields on the certificate resource.
+                type: string
               arn:
                 description: Specifies the ARN of the PCA resource
                 type: string

--- a/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaissuers.yaml
+++ b/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaissuers.yaml
@@ -37,7 +37,7 @@ spec:
             description: AWSPCAIssuerSpec defines the desired state of AWSPCAIssuer
             properties:
               pcaTemplateName:
-                description: Specifies the template name of the issuer
+                description: Specifies the template name associated with the issuer, all requests made to this issuer will use this template. If not specified, the issuer will follow the fields on the certificate resource.
                   certificates. If not specified, the issuer will follow the fields on the certificate resource.
                 type: string
               arn:

--- a/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaissuers.yaml
+++ b/charts/aws-pca-issuer/crds/awspca.cert-manager.io_awspcaissuers.yaml
@@ -37,8 +37,8 @@ spec:
             description: AWSPCAIssuerSpec defines the desired state of AWSPCAIssuer
             properties:
               pcaTemplateName:
-                description: Specifies the template name associated with the issuer, all requests made to this issuer will use this template. If not specified, the issuer will follow the fields on the certificate resource.
-                  certificates. If not specified, the issuer will follow the fields on the certificate resource.
+                description: Specifies the template name associated with the issuer, all requests made to this issuer will use this template. If not specified, the issuer will use the usageTypes on the certificate resource.
+                  certificates. 
                 type: string
               arn:
                 description: Specifies the ARN of the PCA resource

--- a/config/crd/bases/awspca.cert-manager.io_awspcaclusterissuers.yaml
+++ b/config/crd/bases/awspca.cert-manager.io_awspcaclusterissuers.yaml
@@ -43,6 +43,12 @@ spec:
               arn:
                 description: Specifies the ARN of the PCA resource
                 type: string
+              pcaTemplateName:
+                description: Specifies the template name associated with the issuer,
+                  all requests made to this issuer will use this template. If not
+                  specified, the issuer will follow the fields on the certificate
+                  resource.
+                type: string
               region:
                 description: Should contain the AWS region if it cannot be inferred
                 type: string
@@ -110,9 +116,6 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
-              pcaTemplateName:
-                description: Specifies the template name of the issuer
-                type: string
             type: object
           status:
             description: AWSPCAIssuerStatus defines the observed state of AWSPCAIssuer

--- a/config/crd/bases/awspca.cert-manager.io_awspcaclusterissuers.yaml
+++ b/config/crd/bases/awspca.cert-manager.io_awspcaclusterissuers.yaml
@@ -110,6 +110,9 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              pcaTemplateName:
+                description: Specifies the template name of the issuer
+                type: string
             type: object
           status:
             description: AWSPCAIssuerStatus defines the observed state of AWSPCAIssuer

--- a/config/crd/bases/awspca.cert-manager.io_awspcaclusterissuers.yaml
+++ b/config/crd/bases/awspca.cert-manager.io_awspcaclusterissuers.yaml
@@ -46,7 +46,7 @@ spec:
               pcaTemplateName:
                 description: Specifies the template name associated with the issuer,
                   all requests made to this issuer will use this template. If not
-                  specified, the issuer will follow the fields on the certificate
+                  specified, the issuer will use the usageTypes on the certificate
                   resource.
                 type: string
               region:

--- a/config/crd/bases/awspca.cert-manager.io_awspcaissuers.yaml
+++ b/config/crd/bases/awspca.cert-manager.io_awspcaissuers.yaml
@@ -109,6 +109,9 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              pcaTemplateName:
+                description: Specifies the template name of the issuer
+                type: string
             type: object
           status:
             description: AWSPCAIssuerStatus defines the observed state of AWSPCAIssuer

--- a/config/crd/bases/awspca.cert-manager.io_awspcaissuers.yaml
+++ b/config/crd/bases/awspca.cert-manager.io_awspcaissuers.yaml
@@ -42,6 +42,12 @@ spec:
               arn:
                 description: Specifies the ARN of the PCA resource
                 type: string
+              pcaTemplateName:
+                description: Specifies the template name associated with the issuer,
+                  all requests made to this issuer will use this template. If not
+                  specified, the issuer will follow the fields on the certificate
+                  resource.
+                type: string
               region:
                 description: Should contain the AWS region if it cannot be inferred
                 type: string
@@ -109,9 +115,6 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
-              pcaTemplateName:
-                description: Specifies the template name of the issuer
-                type: string
             type: object
           status:
             description: AWSPCAIssuerStatus defines the observed state of AWSPCAIssuer

--- a/config/crd/bases/awspca.cert-manager.io_awspcaissuers.yaml
+++ b/config/crd/bases/awspca.cert-manager.io_awspcaissuers.yaml
@@ -45,7 +45,7 @@ spec:
               pcaTemplateName:
                 description: Specifies the template name associated with the issuer,
                   all requests made to this issuer will use this template. If not
-                  specified, the issuer will follow the fields on the certificate
+                  specified, the issuer will use the usageTypes on the certificate
                   resource.
                 type: string
               region:

--- a/config/examples/config/issuer-with-template.yaml
+++ b/config/examples/config/issuer-with-template.yaml
@@ -1,0 +1,12 @@
+apiVersion: awspca.cert-manager.io/v1beta1
+kind: AWSPCAIssuer
+metadata:
+  name: example
+  namespace: default
+spec:
+  arn: <some-pca-arn>
+  region: eu-west-1
+  pcaTemplateName: SubordinateCACertificate_PathLen1/V1
+  secretRef:
+    namespace: default
+    name: example

--- a/e2e/common_steps.go
+++ b/e2e/common_steps.go
@@ -6,15 +6,14 @@ import (
 	"strings"
 	"time"
 
+	"crypto/x509"
+	"encoding/pem"
 	util "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cucumber/godog"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-
-	"crypto/x509"
-	"encoding/pem"
 	"slices"
 
 	"github.com/cert-manager/aws-privateca-issuer/pkg/api/v1beta1"

--- a/e2e/common_steps.go
+++ b/e2e/common_steps.go
@@ -6,14 +6,15 @@ import (
 	"strings"
 	"time"
 
-	"crypto/x509"
-	"encoding/pem"
-	util "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cucumber/godog"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	util "github.com/cert-manager/cert-manager/pkg/api/util"
+	
+	"crypto/x509"
+	"encoding/pem"
 	"slices"
 
 	"github.com/cert-manager/aws-privateca-issuer/pkg/api/v1beta1"

--- a/e2e/common_steps.go
+++ b/e2e/common_steps.go
@@ -6,12 +6,12 @@ import (
 	"strings"
 	"time"
 
+	util "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cucumber/godog"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-	util "github.com/cert-manager/cert-manager/pkg/api/util"
 
 	"crypto/x509"
 	"encoding/pem"
@@ -40,7 +40,6 @@ var usageMap = map[string]cmv1.KeyUsage{
 	"ipsec user":        cmv1.UsageIPsecUser,
 	"ipsec tunnel":      cmv1.UsageIPsecTunnel,
 }
-
 
 func getCaArn(caType string) string {
 	caArn, exists := testContext.caArns[caType]
@@ -232,9 +231,9 @@ func parseUsages(usageStr string) []cmv1.KeyUsage {
 	var usages []cmv1.KeyUsage
 	for _, part := range parts {
 		if usage, exists := usageMap[strings.ToLower(part)]; exists {
-			usages = append(usages, usage) 
+			usages = append(usages, usage)
 		} else {
-			usages = append(usages, cmv1.KeyUsage(part)) 
+			usages = append(usages, cmv1.KeyUsage(part))
 		}
 	}
 
@@ -294,7 +293,7 @@ func (issCtx *IssuerContext) verifyCertificateContent(ctx context.Context, usage
 		if !exists {
 			assert.FailNow(godog.T(ctx), "Expected usage %q not found in usageMap.", expectedUsage)
 		}
-		
+
 		x509Usage, _ := util.ExtKeyUsageType(mappedUsage)
 		if !slices.Contains(cert.ExtKeyUsage, x509Usage) {
 			assert.FailNow(godog.T(ctx), fmt.Sprintf("Certificate usage mismatch. Found: %v, Expected: %v", cert.ExtKeyUsage, mappedUsage))

--- a/e2e/common_steps.go
+++ b/e2e/common_steps.go
@@ -6,16 +6,16 @@ import (
 	"strings"
 	"time"
 
+	"crypto/x509"
+	"encoding/pem"
+	"slices"
+
+	util "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cucumber/godog"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-	util "github.com/cert-manager/cert-manager/pkg/api/util"
-	
-	"crypto/x509"
-	"encoding/pem"
-	"slices"
 
 	"github.com/cert-manager/aws-privateca-issuer/pkg/api/v1beta1"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/api/v1beta1/awspcaissuer_types.go
+++ b/pkg/api/v1beta1/awspcaissuer_types.go
@@ -37,7 +37,7 @@ type AWSPCAIssuerSpec struct {
 	// Needs to be specified if you want to authorize with AWS using an access and secret key
 	// +optional
 	SecretRef AWSCredentialsSecretReference `json:"secretRef,omitempty"`
-	// Specifies the template name associated with the issuer, all requests made to this issuer will use this template. If not specified, the issuer will follow the fields on the certificate resource.
+	// Specifies the template name associated with the issuer, all requests made to this issuer will use this template. If not specified, the issuer will use the usageTypes on the certificate resource.
 	// +optional
 	PCATemplateName string `json:"pcaTemplateName,omitempty"`
 }

--- a/pkg/api/v1beta1/awspcaissuer_types.go
+++ b/pkg/api/v1beta1/awspcaissuer_types.go
@@ -37,6 +37,9 @@ type AWSPCAIssuerSpec struct {
 	// Needs to be specified if you want to authorize with AWS using an access and secret key
 	// +optional
 	SecretRef AWSCredentialsSecretReference `json:"secretRef,omitempty"`
+	// Specifies the template name of the issuer
+	// +optional
+	TemplateArn string `json:"templateArn,omitempty"`
 }
 
 // AWSCredentialsSecretReference defines the secret used by the issuer

--- a/pkg/api/v1beta1/awspcaissuer_types.go
+++ b/pkg/api/v1beta1/awspcaissuer_types.go
@@ -37,9 +37,9 @@ type AWSPCAIssuerSpec struct {
 	// Needs to be specified if you want to authorize with AWS using an access and secret key
 	// +optional
 	SecretRef AWSCredentialsSecretReference `json:"secretRef,omitempty"`
-	// Specifies the template name of the issuer
+	// Specifies the template name associated with the issuer, all requests made to this issuer will use this template. If not specified, the issuer will follow the fields on the certificate resource.
 	// +optional
-	TemplateArn string `json:"templateArn,omitempty"`
+	PCATemplateName string `json:"pcaTemplateName,omitempty"`
 }
 
 // AWSCredentialsSecretReference defines the secret used by the issuer

--- a/pkg/api/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/api/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/aws/pca.go
+++ b/pkg/aws/pca.go
@@ -280,7 +280,8 @@ func (p *PCAProvisioner) now() time.Time {
 
 func buildTemplateArn(caArn string, spec cmapi.CertificateRequestSpec, templateName string) string {
 	arn := strings.SplitAfterN(caArn, ":", 3)
-	prefix := arn[0] + arn[1] + "acm-pca:::template/"
+	arnPrefix, partition := arn[0], arn[1]
+	prefix := arnPrefix + partition + "acm-pca:::template/"
 
 	if templateName != "" {
 		return prefix + templateName

--- a/pkg/aws/pca.go
+++ b/pkg/aws/pca.go
@@ -56,7 +56,7 @@ var collection = new(sync.Map)
 // GenericProvisioner abstracts over the Provisioner type for mocking purposes
 type GenericProvisioner interface {
 	Get(ctx context.Context, cr *cmapi.CertificateRequest, certArn string, log logr.Logger) ([]byte, []byte, error)
-	Sign(ctx context.Context, cr *cmapi.CertificateRequest, log logr.Logger) error
+	Sign(ctx context.Context, cr *cmapi.CertificateRequest, pcaTemplateName string, log logr.Logger) error
 }
 
 // acmPCAClient abstracts over the methods used from acmpca.Client
@@ -182,7 +182,7 @@ func idempotencyToken(cr *cmapi.CertificateRequest) string {
 }
 
 // Sign takes a certificate request and signs it using PCA
-func (p *PCAProvisioner) Sign(ctx context.Context, cr *cmapi.CertificateRequest, log logr.Logger) error {
+func (p *PCAProvisioner) Sign(ctx context.Context, cr *cmapi.CertificateRequest, tempArn string, log logr.Logger) error {
 	block, _ := pem.Decode(cr.Spec.Request)
 	if block == nil {
 		return fmt.Errorf("failed to decode CSR")
@@ -192,8 +192,6 @@ func (p *PCAProvisioner) Sign(ctx context.Context, cr *cmapi.CertificateRequest,
 	if cr.Spec.Duration != nil {
 		validityExpiration = int64(p.now().Unix()) + int64(cr.Spec.Duration.Seconds())
 	}
-
-	tempArn := templateArn(p.arn, cr.Spec)
 
 	// Consider it a "retry" if we try to re-create a cert with the same name in the same namespace
 	token := idempotencyToken(cr)
@@ -278,34 +276,38 @@ func (p *PCAProvisioner) now() time.Time {
 	return time.Now()
 }
 
-func templateArn(caArn string, spec cmapi.CertificateRequestSpec) string {
+func BuildTemplateArn(caArn string, spec cmapi.CertificateRequestSpec, issuerSpec *api.AWSPCAIssuerSpec) string {
 	arn := strings.SplitAfterN(caArn, ":", 3)
-	prefix := arn[0] + arn[1]
+	prefix := arn[0] + arn[1] + "acm-pca:::template/"
+
+	if issuerSpec != nil && issuerSpec.TemplateArn != "" {
+		return prefix + issuerSpec.TemplateArn
+	}
 
 	if spec.IsCA {
-		return prefix + "acm-pca:::template/SubordinateCACertificate_PathLen0/V1"
+		return prefix + "SubordinateCACertificate_PathLen0/V1"
 	}
 
 	if len(spec.Usages) == 1 {
 		switch spec.Usages[0] {
 		case cmapi.UsageCodeSigning:
-			return prefix + "acm-pca:::template/CodeSigningCertificate/V1"
+			return prefix + "CodeSigningCertificate/V1"
 		case cmapi.UsageClientAuth:
-			return prefix + "acm-pca:::template/EndEntityClientAuthCertificate/V1"
+			return prefix + "EndEntityClientAuthCertificate/V1"
 		case cmapi.UsageServerAuth:
-			return prefix + "acm-pca:::template/EndEntityServerAuthCertificate/V1"
+			return prefix + "EndEntityServerAuthCertificate/V1"
 		case cmapi.UsageOCSPSigning:
-			return prefix + "acm-pca:::template/OCSPSigningCertificate/V1"
+			return prefix + "OCSPSigningCertificate/V1"
 		}
 	} else if len(spec.Usages) == 2 {
 		clientServer := (spec.Usages[0] == cmapi.UsageClientAuth && spec.Usages[1] == cmapi.UsageServerAuth)
 		serverClient := (spec.Usages[0] == cmapi.UsageServerAuth && spec.Usages[1] == cmapi.UsageClientAuth)
 		if clientServer || serverClient {
-			return prefix + "acm-pca:::template/EndEntityCertificate/V1"
+			return prefix + "EndEntityCertificate/V1"
 		}
 	}
 
-	return prefix + "acm-pca:::template/BlankEndEntityCertificate_APICSRPassthrough/V1"
+	return prefix + "BlankEndEntityCertificate_APICSRPassthrough/V1"
 }
 
 func splitRootCACertificate(caCertChainPem []byte) ([]byte, []byte, error) {

--- a/pkg/aws/pca_test.go
+++ b/pkg/aws/pca_test.go
@@ -164,9 +164,9 @@ type errorACMPCAClient struct {
 }
 
 type pcaTemplateTestCase struct {
-	expectedSuffix  string
-	certificateSpec cmapi.CertificateRequestSpec
-	templateName    string
+	expectedTemplateArn string
+	certificateSpec     cmapi.CertificateRequestSpec
+	templateName        string
 }
 
 func (m *errorACMPCAClient) DescribeCertificateAuthority(_ context.Context, input *acmpca.DescribeCertificateAuthorityInput, _ ...func(*acmpca.Options)) (*acmpca.DescribeCertificateAuthorityOutput, error) {
@@ -259,9 +259,9 @@ func TestProvisonerOperation(t *testing.T) {
 	assert.Equal(t, err, nil)
 }
 
-func createPCATemplateTestCase(suffix string, usages []cmapi.KeyUsage, isCA bool, pcaTemplateName string) pcaTemplateTestCase {
+func createPCATemplateTestCase(expectedTemplateName string, usages []cmapi.KeyUsage, isCA bool, pcaTemplateName string) pcaTemplateTestCase {
 	tc := pcaTemplateTestCase{
-		expectedSuffix: ":acm-pca:::template/" + suffix,
+		expectedTemplateArn: ":acm-pca:::template/" + expectedTemplateName,
 		certificateSpec: cmapi.CertificateRequestSpec{
 			Usages: usages,
 			IsCA:   isCA,
@@ -300,19 +300,19 @@ func TestPCATemplateArn(t *testing.T) {
 		templateName := tc.templateName
 		t.Run(name, func(t *testing.T) {
 			response := buildTemplateArn(arn, certificateSpec, templateName)
-			assert.True(t, strings.HasSuffix(response, tc.expectedSuffix), "returns expected template")
+			assert.True(t, strings.HasSuffix(response, tc.expectedTemplateArn), "returns expected template")
 			assert.True(t, strings.HasPrefix(response, "arn:aws:"), "returns expected ARN prefix")
 		})
 
 		t.Run(name, func(t *testing.T) {
 			response := buildTemplateArn(govArn, certificateSpec, templateName)
-			assert.True(t, strings.HasSuffix(response, tc.expectedSuffix), "us-gov returns expected template")
+			assert.True(t, strings.HasSuffix(response, tc.expectedTemplateArn), "us-gov returns expected template")
 			assert.True(t, strings.HasPrefix(response, "arn:aws-us-gov:"), "us-gov returns expected ARN prefix")
 		})
 
 		t.Run(name, func(t *testing.T) {
 			response := buildTemplateArn(fakeArn, certificateSpec, templateName)
-			assert.True(t, strings.HasSuffix(response, tc.expectedSuffix), "fake arn returns expected template")
+			assert.True(t, strings.HasSuffix(response, tc.expectedTemplateArn), "fake arn returns expected template")
 			assert.True(t, strings.HasPrefix(response, "arn:fake:"), "fake arn returns expected ARN prefix")
 		})
 	}

--- a/pkg/controllers/certificaterequest_controller.go
+++ b/pkg/controllers/certificaterequest_controller.go
@@ -169,8 +169,7 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	certArn, exists := cr.ObjectMeta.GetAnnotations()["aws-privateca-issuer/certificate-arn"]
 	if !exists {
-		issSpec := iss.GetSpec()
-		err := provisioner.Sign(ctx, cr, issSpec.PCATemplateName, log)
+		err := provisioner.Sign(ctx, cr, iss.GetSpec().PCATemplateName, log)
 		if err != nil {
 			log.Error(err, "failed to request certificate from PCA")
 			return ctrl.Result{}, r.setStatus(ctx, cr, cmmeta.ConditionFalse, cmapi.CertificateRequestReasonFailed, "failed to request certificate from PCA: "+err.Error())

--- a/pkg/controllers/certificaterequest_controller.go
+++ b/pkg/controllers/certificaterequest_controller.go
@@ -169,7 +169,8 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	certArn, exists := cr.ObjectMeta.GetAnnotations()["aws-privateca-issuer/certificate-arn"]
 	if !exists {
-		err := provisioner.Sign(ctx, cr, log)
+		templateArn := awspca.BuildTemplateArn(iss.GetSpec().Arn, cr.Spec, iss.GetSpec())
+		err := provisioner.Sign(ctx, cr, templateArn, log)
 		if err != nil {
 			log.Error(err, "failed to request certificate from PCA")
 			return ctrl.Result{}, r.setStatus(ctx, cr, cmmeta.ConditionFalse, cmapi.CertificateRequestReasonFailed, "failed to request certificate from PCA: "+err.Error())

--- a/pkg/controllers/certificaterequest_controller.go
+++ b/pkg/controllers/certificaterequest_controller.go
@@ -169,8 +169,8 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	certArn, exists := cr.ObjectMeta.GetAnnotations()["aws-privateca-issuer/certificate-arn"]
 	if !exists {
-		templateArn := awspca.BuildTemplateArn(iss.GetSpec().Arn, cr.Spec, iss.GetSpec())
-		err := provisioner.Sign(ctx, cr, templateArn, log)
+		issSpec := iss.GetSpec()
+		err := provisioner.Sign(ctx, cr, issSpec.PCATemplateName, log)
 		if err != nil {
 			log.Error(err, "failed to request certificate from PCA")
 			return ctrl.Result{}, r.setStatus(ctx, cr, cmmeta.ConditionFalse, cmapi.CertificateRequestReasonFailed, "failed to request certificate from PCA: "+err.Error())

--- a/pkg/controllers/certificaterequest_controller_test.go
+++ b/pkg/controllers/certificaterequest_controller_test.go
@@ -718,10 +718,6 @@ func TestCertificateRequestReconcile(t *testing.T) {
 			result, getErr := controller.Reconcile(ctx, reconcile.Request{NamespacedName: tc.name})
 			assert.Equal(t, tc.expectedGetResult, result, "Unexpected get result")
 
-			if tc.expectedTemplate != "" {
-				assert.Equal(t, tc.expectedTemplate, templateTestProvisioner.pcaTemplateName)
-			}
-
 			if tc.expectedError && (signErr == nil && getErr == nil) {
 				assert.Fail(t, "Expected an error but got none")
 			}

--- a/pkg/controllers/certificaterequest_controller_test.go
+++ b/pkg/controllers/certificaterequest_controller_test.go
@@ -706,7 +706,7 @@ func TestCertificateRequestReconcile(t *testing.T) {
 				GetProvisioner = tc.mockProvisioner
 			}
 
-			var templateTestProvisioner *fakeProvisioner
+			templateTestProvisioner := &fakeProvisioner{}
 			if tc.expectedTemplate != "" {
 				templateTestProvisioner = &fakeProvisioner{caCert: []byte("cacert"), cert: []byte("cert")}
 				GetProvisioner = generateMockGetProvisioner(templateTestProvisioner, nil)
@@ -717,6 +717,8 @@ func TestCertificateRequestReconcile(t *testing.T) {
 
 			result, getErr := controller.Reconcile(ctx, reconcile.Request{NamespacedName: tc.name})
 			assert.Equal(t, tc.expectedGetResult, result, "Unexpected get result")
+
+			assert.Equal(t, tc.expectedTemplate, templateTestProvisioner.pcaTemplateName)
 
 			if tc.expectedError && (signErr == nil && getErr == nil) {
 				assert.Fail(t, "Expected an error but got none")

--- a/pkg/controllers/certificaterequest_controller_test.go
+++ b/pkg/controllers/certificaterequest_controller_test.go
@@ -51,7 +51,7 @@ type fakeProvisioner struct {
 	signErr error
 }
 
-func (p *fakeProvisioner) Sign(ctx context.Context, cr *cmapi.CertificateRequest, log logr.Logger) error {
+func (p *fakeProvisioner) Sign(ctx context.Context, cr *cmapi.CertificateRequest, pcaTemplateName string, log logr.Logger) error {
 	metav1.SetMetaDataAnnotation(&cr.ObjectMeta, "aws-privateca-issuer/certificate-arn", "arn")
 	return p.signErr
 }

--- a/pkg/util/issuers.go
+++ b/pkg/util/issuers.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"context"
+
 	api "github.com/cert-manager/aws-privateca-issuer/pkg/api/v1beta1"
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
The charts were updated to accept a pcaTemplateName that maps to a template ARN. There is a new example showing this. The template mapping was updated to reflect this. The controllers were adjusted to call the updated function. The unit testing was updated to validate the BuildTemplateArn function.